### PR TITLE
migrate.sh skips migrations across environment

### DIFF
--- a/ixc_django_docker/bin/migrate.sh
+++ b/ixc_django_docker/bin/migrate.sh
@@ -21,7 +21,7 @@ manage.py migrate --list > "$DIR/migrate.txt"
 
 # Is local listing of migrations the same as one cached in Redis
 # (i.e. as has already been completed and cached by another server instance)?
-if ! redis-cache.py -x match ixc-django-docker:migrate-list < "$DIR/migrate.txt" > /dev/null 2>&1; then
+if ! redis-cache.py -v -x match ixc-django-docker:migrate-list < "$DIR/migrate.txt"; then
 	echo 'Migrations are out of date.'
 
 	# Skip initial migration if all tables created by the initial migration
@@ -35,5 +35,5 @@ if ! redis-cache.py -x match ixc-django-docker:migrate-list < "$DIR/migrate.txt"
 	manage.py migrate --list > "$DIR/migrate.txt"
 
 	# Cache listing of up-to-date migrations
-	redis-cache.py -x set ixc-django-docker:migrate-list < "$DIR/migrate.txt"
+	redis-cache.py -vv -x set ixc-django-docker:migrate-list < "$DIR/migrate.txt"
 fi

--- a/ixc_django_docker/bin/migrate.sh
+++ b/ixc_django_docker/bin/migrate.sh
@@ -17,10 +17,11 @@ if [[ $(python -c 'import django; print(django.get_version());') < 1.7 ]]; then
 	manage.py syncdb --noinput
 fi
 
-touch "$DIR/migrate.txt.md5"
 manage.py migrate --list > "$DIR/migrate.txt"
 
-if [[ ! -s "$DIR/migrate.txt.md5" ]] || ! md5sum --status -c "$DIR/migrate.txt.md5" > /dev/null 2>&1; then
+# Is local listing of migrations the same as one cached in Redis
+# (i.e. as has already been completed and cached by another server instance)?
+if ! redis-cache.py -x match ixc-django-docker:migrate-list < "$DIR/migrate.txt" > /dev/null 2>&1; then
 	echo 'Migrations are out of date.'
 
 	# Skip initial migration if all tables created by the initial migration
@@ -32,5 +33,7 @@ if [[ ! -s "$DIR/migrate.txt.md5" ]] || ! md5sum --status -c "$DIR/migrate.txt.m
 	fi
 
 	manage.py migrate --list > "$DIR/migrate.txt"
-	md5sum "$DIR/migrate.txt" > "$DIR/migrate.txt.md5"
+
+	# Cache listing of up-to-date migrations
+	redis-cache.py -x set ixc-django-docker:migrate-list < "$DIR/migrate.txt"
 fi

--- a/ixc_django_docker/bin/redis-cache.py
+++ b/ixc_django_docker/bin/redis-cache.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python
+
+""" Set and fetch data cached in Redis """
+
+import os
+import sys
+import argparse
+import logging
+
+import redis
+
+logging.basicConfig(format='%(message)s')
+logger = logging.getLogger(__name__)
+
+REDIS_HOST, REDIS_PORT = \
+    os.environ.get('REDIS_ADDRESS', 'localhost:6379').split(':')
+
+TIMEOUT_SECS = 60 * 60  # 1 hour
+
+ACTION_CHOICES = ['set', 'set-and-match', 'get']
+
+
+def fault(parser, message=None):
+    if message:
+        sys.stderr.write(message + '\n')
+    else:
+        parser.print_help()
+    sys.exit(1)
+
+
+def redis_set(conn, key, value, expiry_secs):
+    return conn.set(key, value, ex=expiry_secs)
+
+
+def redis_get(conn, key):
+    return conn.get(key)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Set or fetch data cached in Redis',
+        formatter_class=argparse.RawTextHelpFormatter,
+    )
+    parser.add_argument(
+        'action',
+        choices=ACTION_CHOICES,
+        help=(
+            "Action to perform:\n"
+            "\n"
+            "'set': set Redis <key> to the given <value> argument or data\n"
+            "       read from STDIN if the [-x] option is set\n"
+            "\n"
+            "'get': echo value in Redis for <key> to STDOUT.\n"
+            "       Returns ERRORLEVEL 100 if there is no such key in Redis\n"
+            "\n"
+            "'set-and-match': return ERRORLEVEL 0 if Redis has a value for\n"
+            "       <key> matching the given <value> argument or STDIN,\n"
+            "       or ERRORLEVEL 100 if there is no match.\n"
+            "       Also 'set' the given value in Redis either way."
+            "\n"
+        ),
+    )
+    parser.add_argument(
+        'key',
+        help='Cache key name',
+    )
+    parser.add_argument(
+        'value',
+        nargs='?',
+        help=(
+            'Value to set in cache, valid only for actions: %s'
+            % ', '.join(ACTION_CHOICES[:-1])
+        )
+    )
+    parser.add_argument(
+        '--redis-host',
+        default=REDIS_HOST,
+        help='Host of redis server (default: %s)' % REDIS_HOST,
+    )
+    parser.add_argument(
+        '--redis-port',
+        default=REDIS_PORT,
+        help='Port of redis server (default: %s)' % REDIS_PORT,
+    )
+    parser.add_argument(
+        '--expire-secs',
+        default=TIMEOUT_SECS,
+        help=(
+            'Expiry timeout in seconds for cached values (default: %s)'
+            % TIMEOUT_SECS
+        ),
+    )
+    parser.add_argument(
+        '-x',
+        dest='read_from_stdin',
+        action='store_true',
+        default=False,
+        help='Read last argument from STDIN',
+    )
+    args = parser.parse_args()
+
+    # Read input data from <value> argument or STDIN as requested, and
+    # sanity-check argument values and combinations
+    if args.action in ACTION_CHOICES[:-1]:  # Set actions
+        if args.read_from_stdin:
+            input_data = sys.stdin.read()
+        elif not args.value:
+            fault(
+                parser,
+                "You must provide <value> as a third argument or read from"
+                " STDIN by setting the [-x] option"
+            )
+        else:
+            input_data = args.value
+    else:  # Get action
+        if args.value or args.read_from_stdin:
+            fault(
+                parser,
+                "You cannot provide <value> as an argument or read from STDIN"
+                " by setting the [-x] option for get actions"
+            )
+
+    conn = redis.Redis(
+        host=args.redis_host, port=args.redis_port,
+    )
+
+    if args.action == 'set':
+        redis_set(conn, args.key, input_data, args.expire_secs)
+    elif args.action == 'get':
+        cached_data = redis_get(conn, args.key)
+        if cached_data is None:
+            sys.exit(100)
+        else:
+            sys.stdout.write(cached_data + "\n")
+    elif args.action == 'set-and-match':
+        # Read cached data
+        cached_data = redis_get(conn, args.key)
+        # Does cached data match input data?
+        is_match = cached_data == input_data
+        # Set/update the value in Redis either way
+        redis_set(conn, args.key, input_data, args.expire_secs)
+        if is_match:
+            return
+        else:
+            sys.exit(100)
+    else:
+        raise Exception("Unimplemented action '%s'" % args.action)
+
+if __name__ == '__main__':
+    main()

--- a/ixc_django_docker/bin/redis-cache.py
+++ b/ixc_django_docker/bin/redis-cache.py
@@ -122,7 +122,7 @@ def main():
                 " by setting the [-x] option for get actions"
             )
 
-    conn = redis.Redis(
+    conn = redis.StrictRedis(
         host=args.redis_host, port=args.redis_port,
     )
 

--- a/ixc_django_docker/bin/redis-cache.py
+++ b/ixc_django_docker/bin/redis-cache.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 REDIS_HOST, REDIS_PORT = \
     os.environ.get('REDIS_ADDRESS', 'localhost:6379').split(':')
 
-TIMEOUT_SECS = 60 * 60  # 1 hour
+DEFAULT_EXPIRE_TIMEOUT_SECS = None
 
 ACTION_CHOICES = ['set', 'match', 'get', 'delete']
 
@@ -86,10 +86,10 @@ def main():
     )
     parser.add_argument(
         '--expire-secs',
-        default=TIMEOUT_SECS,
+        default=DEFAULT_EXPIRE_TIMEOUT_SECS,
         help=(
             'Expiry timeout in seconds for cached values (default: %s)'
-            % TIMEOUT_SECS
+            % DEFAULT_EXPIRE_TIMEOUT_SECS
         ),
     )
     parser.add_argument(

--- a/ixc_django_docker/bin/redis-cache.py
+++ b/ixc_django_docker/bin/redis-cache.py
@@ -17,7 +17,7 @@ REDIS_HOST, REDIS_PORT = \
 
 TIMEOUT_SECS = 60 * 60  # 1 hour
 
-ACTION_CHOICES = ['set', 'set-and-match', 'get']
+ACTION_CHOICES = ['set', 'set-and-match', 'match', 'get']
 
 
 def fault(parser, message=None):
@@ -52,6 +52,10 @@ def main():
             "\n"
             "'get': echo value in Redis for <key> to STDOUT.\n"
             "       Returns ERRORLEVEL 100 if there is no such key in Redis\n"
+            "\n"
+            "'match': return ERRORLEVEL 0 if Redis has a value for\n"
+            "       <key> matching the given <value> argument or STDIN,\n"
+            "       or ERRORLEVEL 100 if there is no match.\n"
             "\n"
             "'set-and-match': return ERRORLEVEL 0 if Redis has a value for\n"
             "       <key> matching the given <value> argument or STDIN,\n"
@@ -132,13 +136,14 @@ def main():
             sys.exit(100)
         else:
             sys.stdout.write(cached_data + "\n")
-    elif args.action == 'set-and-match':
+    elif args.action in ('match', 'set-and-match'):
         # Read cached data
         cached_data = redis_get(conn, args.key)
         # Does cached data match input data?
         is_match = cached_data == input_data
-        # Set/update the value in Redis either way
-        redis_set(conn, args.key, input_data, args.expire_secs)
+        if args.action == 'set-and-match':
+            # Set/update the value in Redis either way
+            redis_set(conn, args.key, input_data, args.expire_secs)
         if is_match:
             return
         else:

--- a/ixc_django_docker/bin/redis-cache.py
+++ b/ixc_django_docker/bin/redis-cache.py
@@ -20,10 +20,12 @@ DEFAULT_EXPIRE_TIMEOUT_SECS = None
 ACTION_CHOICES = ['set', 'match', 'get', 'delete']
 
 
-def fault(parser, message=None):
+def fault(parser, logger, message=None):
     if message:
+        logger.error(message)
         sys.stderr.write(message + '\n')
     else:
+        logger.error("Invalid use of program, printing usage instructions")
         parser.print_help()
     sys.exit(1)
 
@@ -51,7 +53,8 @@ def main():
             "       read from STDIN if the [-x] option is set.\n"
             "\n"
             "'get': echo value in Redis for <key> to STDOUT.\n"
-            "       Returns ERRORLEVEL 100 if there is no such key in Redis.\n"
+            "       Returns ERRORLEVEL 100 if there is no such key in Redis,\n"
+            "       so this action also works as an existance check.\n"
             "\n"
             "'delete': delete <key> value from Redis. The <key> value does\n"
             "       not need to exist.\n"
@@ -99,7 +102,38 @@ def main():
         default=False,
         help='Read last argument from STDIN',
     )
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action='store_true',
+        help='Silence standard output',
+    )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        action='count',
+        default=0,
+        dest='verbosity',
+        help='Increase verbosity for each occurrence',
+    )
     args = parser.parse_args()
+
+    # Configure log level with verbosity argument.
+    levels = (
+        # logging.CRITICAL,
+        # logging.ERROR,
+        logging.WARNING,
+        logging.INFO,
+        logging.DEBUG,
+    )
+    try:
+        logger.setLevel(levels[args.verbosity])
+    except IndexError:
+        logger.setLevel(logging.DEBUG)
+    # Silence standard output.
+    if args.quiet:
+        logger.debug("Suppressing STDOUT because the [--quiet] option is set")
+        sys.stdout = open(os.devnull, 'w')
 
     # Read input data from <value> argument or STDIN as requested, and
     # sanity-check argument values and combinations
@@ -109,6 +143,7 @@ def main():
         elif not args.value:
             fault(
                 parser,
+                logger,
                 "You must provide <value> as a third argument or read from"
                 " STDIN by setting the [-x] option"
             )
@@ -118,6 +153,7 @@ def main():
         if args.value or args.read_from_stdin:
             fault(
                 parser,
+                logger,
                 "You cannot provide <value> as an argument or read from STDIN"
                 " by setting the [-x] option for get actions"
             )
@@ -128,24 +164,43 @@ def main():
 
     if args.action == 'set':
         redis_set(conn, args.key, input_data, args.expire_secs)
+        logger.debug(
+            "Set Redis key '%s' to value: %s" % (args.key, input_data))
     elif args.action == 'get':
         cached_data = redis_get(conn, args.key)
+        logger.debug(
+            "Get for Redis key '%s' returned value: %s"
+            % (args.key, cached_data))
         if cached_data is None:
             sys.exit(100)
         else:
             sys.stdout.write(cached_data + "\n")
     elif args.action == 'delete':
         conn.delete(args.key)
+        logger.debug("Deleted Redis key '%s'" % args.key)
     elif args.action == 'match':
         # Read cached data
         cached_data = redis_get(conn, args.key)
         # Does cached data match input data?
+        logger.debug(
+            "Checking for match for Redis key '%s' and input value: %s"
+            % (args.key, input_data))
         if cached_data == input_data:
+            logger.info("Match result YES for Redis key '%s'" % args.key)
             return
         else:
+            logger.info("Match result NO for Redis key '%s'" % args.key)
             sys.exit(100)
     else:
         raise Exception("Unimplemented action '%s'" % args.action)
 
 if __name__ == '__main__':
-    main()
+    # Store original standard output destination
+    orig_stdout = sys.stdout
+    try:
+        main()
+    except:
+        raise
+    finally:
+        # Restore original standard output.
+        sys.stdout = orig_stdout

--- a/ixc_django_docker/bin/redis-cache.py
+++ b/ixc_django_docker/bin/redis-cache.py
@@ -17,7 +17,7 @@ REDIS_HOST, REDIS_PORT = \
 
 TIMEOUT_SECS = 60 * 60  # 1 hour
 
-ACTION_CHOICES = ['set', 'set-and-match', 'match', 'get']
+ACTION_CHOICES = ['set', 'match', 'get']
 
 
 def fault(parser, message=None):
@@ -56,11 +56,6 @@ def main():
             "'match': return ERRORLEVEL 0 if Redis has a value for\n"
             "       <key> matching the given <value> argument or STDIN,\n"
             "       or ERRORLEVEL 100 if there is no match.\n"
-            "\n"
-            "'set-and-match': return ERRORLEVEL 0 if Redis has a value for\n"
-            "       <key> matching the given <value> argument or STDIN,\n"
-            "       or ERRORLEVEL 100 if there is no match.\n"
-            "       Also 'set' the given value in Redis either way."
             "\n"
         ),
     )
@@ -136,15 +131,11 @@ def main():
             sys.exit(100)
         else:
             sys.stdout.write(cached_data + "\n")
-    elif args.action in ('match', 'set-and-match'):
+    elif args.action == 'match':
         # Read cached data
         cached_data = redis_get(conn, args.key)
         # Does cached data match input data?
-        is_match = cached_data == input_data
-        if args.action == 'set-and-match':
-            # Set/update the value in Redis either way
-            redis_set(conn, args.key, input_data, args.expire_secs)
-        if is_match:
+        if cached_data == input_data:
             return
         else:
             sys.exit(100)

--- a/ixc_django_docker/tests/test-redis-cache.sh
+++ b/ixc_django_docker/tests/test-redis-cache.sh
@@ -6,36 +6,44 @@ KEY=test-redis-cache
 TEST_FILENAME=test-redis-cache.out
 EXPIRE_SECS=1
 
-######################
-# Test 'set-and-match'
-######################
-CMD="$PROG -x --expire-secs $EXPIRE_SECS set-and-match $KEY"
+# Run command once to print out error messages if Redis is unavailable etc
+$PROG get $KEY > /dev/null
+
+##############
+# Test 'match'
+##############
+MATCH_CMD="$PROG -x --expire-secs $EXPIRE_SECS match $KEY"
+SET_CMD="$PROG -x --expire-secs $EXPIRE_SECS set $KEY"
 ls -1 > $TEST_FILENAME
 
-if $CMD < $TEST_FILENAME; then
-    echo "FAIL: Expected no match for first run of 'set-and-match'"
+if $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+    echo "FAIL: Expected no match for first run of 'match'"
 fi
 
-if ! $CMD < $TEST_FILENAME; then
-    echo "FAIL: Expected match for second run of 'set-and-match'"
+$SET_CMD < $TEST_FILENAME
+
+if ! $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+    echo "FAIL: Expected match for second run of 'match'"
 fi
 
-if ! $CMD < $TEST_FILENAME; then
-    echo "FAIL: Expected match for third run of 'set-and-match'"
+if ! $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+    echo "FAIL: Expected match for third run of 'match'"
 fi
 
 echo "Changed" >> $TEST_FILENAME
-if $CMD < $TEST_FILENAME; then
-    echo "FAIL: Expected no match for run of 'set-and-match' with changed data"
+if $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+    echo "FAIL: Expected no match for run of 'match' with changed data"
 fi
 
-if ! $CMD < $TEST_FILENAME; then
-    echo "FAIL: Expected match for second run of 'set-and-match' after changed data"
+$SET_CMD < $TEST_FILENAME
+
+if ! $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+    echo "FAIL: Expected match for run of 'match' after changed data re-set"
 fi
 
 sleep 2s  # Must be longer than $EXPIRE_SECS
-if $CMD < $TEST_FILENAME; then
-    echo "FAIL: Expected no match for run of 'set-and-match' after delay where cached data should expire"
+if $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+    echo "FAIL: Expected no match for run of 'match' after delay where cached data should expire"
 fi
 
 rm $TEST_FILENAME

--- a/ixc_django_docker/tests/test-redis-cache.sh
+++ b/ixc_django_docker/tests/test-redis-cache.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+PROG="ixc_django_docker/bin/redis-cache.py"
+
+KEY=test-redis-cache
+TEST_FILENAME=test-redis-cache.out
+EXPIRE_SECS=1
+
+######################
+# Test 'set-and-match'
+######################
+CMD="$PROG -x --expire-secs $EXPIRE_SECS set-and-match $KEY"
+ls -1 > $TEST_FILENAME
+
+if $CMD < $TEST_FILENAME; then
+    echo "FAIL: Expected no match for first run of 'set-and-match'"
+fi
+
+if ! $CMD < $TEST_FILENAME; then
+    echo "FAIL: Expected match for second run of 'set-and-match'"
+fi
+
+if ! $CMD < $TEST_FILENAME; then
+    echo "FAIL: Expected match for third run of 'set-and-match'"
+fi
+
+echo "Changed" >> $TEST_FILENAME
+if $CMD < $TEST_FILENAME; then
+    echo "FAIL: Expected no match for run of 'set-and-match' with changed data"
+fi
+
+if ! $CMD < $TEST_FILENAME; then
+    echo "FAIL: Expected match for second run of 'set-and-match' after changed data"
+fi
+
+sleep 2s  # Must be longer than $EXPIRE_SECS
+if $CMD < $TEST_FILENAME; then
+    echo "FAIL: Expected no match for run of 'set-and-match' after delay where cached data should expire"
+fi
+
+rm $TEST_FILENAME

--- a/ixc_django_docker/tests/test-redis-cache.sh
+++ b/ixc_django_docker/tests/test-redis-cache.sh
@@ -4,45 +4,45 @@ PROG="ixc_django_docker/bin/redis-cache.py"
 
 KEY=test-redis-cache
 TEST_FILENAME=test-redis-cache.out
-EXPIRE_SECS=1
 
 # Run command once to print out error messages if Redis is unavailable etc
-$PROG get $KEY > /dev/null
+$PROG set $KEY "dummy value"
 
 ##############
 # Test 'match'
 ##############
-MATCH_CMD="$PROG -x --expire-secs $EXPIRE_SECS match $KEY"
-SET_CMD="$PROG -x --expire-secs $EXPIRE_SECS set $KEY"
 ls -1 > $TEST_FILENAME
 
-if $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+if $PROG -x match $KEY < $TEST_FILENAME; then
     echo "FAIL: Expected no match for first run of 'match'"
 fi
 
-$SET_CMD < $TEST_FILENAME
+$PROG -x set $KEY < $TEST_FILENAME
 
-if ! $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+if ! $PROG -x match $KEY < $TEST_FILENAME; then
     echo "FAIL: Expected match for second run of 'match'"
 fi
 
-if ! $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+if ! $PROG -x match $KEY < $TEST_FILENAME; then
     echo "FAIL: Expected match for third run of 'match'"
 fi
 
 echo "Changed" >> $TEST_FILENAME
-if $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+if $PROG -x match $KEY < $TEST_FILENAME; then
     echo "FAIL: Expected no match for run of 'match' with changed data"
 fi
 
-$SET_CMD < $TEST_FILENAME
+$PROG -x set $KEY < $TEST_FILENAME
 
-if ! $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+if ! $PROG -x match $KEY < $TEST_FILENAME; then
     echo "FAIL: Expected match for run of 'match' after changed data re-set"
 fi
 
-sleep 2s  # Must be longer than $EXPIRE_SECS
-if $MATCH_CMD < $TEST_FILENAME > /dev/null 2>&1; then
+# Set expiry timeout for cached data
+$PROG -x --expire-secs 1 set $KEY < $TEST_FILENAME
+
+sleep 2s  # Must be longer than expiry timeout
+if $PROG -x match $KEY < $TEST_FILENAME; then
     echo "FAIL: Expected no match for run of 'match' after delay where cached data should expire"
 fi
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         'ixc_django_docker/bin/npm-install.sh',
         'ixc_django_docker/bin/pip-install.sh',
         'ixc_django_docker/bin/pydevd.sh',
+        'ixc_django_docker/bin/redis-cache.py',
         'ixc_django_docker/bin/runserver.sh',
         'ixc_django_docker/bin/runtests.sh',
         'ixc_django_docker/bin/setup-django.sh',


### PR DESCRIPTION
The migrate.sh script now uses redis-cache.py to check whether migrations have already been run by another server/container within a eployment environment.

Already-run migrations are flagged by Redis having a cached migration listing that exactly matches the locally generated one.