### PR TITLE
Hijack django-post-office email-sending with bandit

### DIFF
--- a/ixc_django_docker/settings/email_bandit.py
+++ b/ixc_django_docker/settings/email_bandit.py
@@ -1,11 +1,20 @@
 import os
 
-HIJACKED_EMAIL_BACKEND = EMAIL_BACKEND
+# Hijack django-post-office backend if project is using that lib...
+if 'POST_OFFICE' in locals():
+    HIJACKED_EMAIL_BACKEND = POST_OFFICE['BACKENDS']['default']
+    POST_OFFICE['BACKENDS']['default'] = \
+        'ixc_django_docker.bandit.HijackedEmailBackend'
+# ...otherwise hijack default Django backend
+else:
+    HIJACKED_EMAIL_BACKEND = EMAIL_BACKEND
+    EMAIL_BACKEND = 'ixc_django_docker.bandit.HijackedEmailBackend'
 
 BANDIT_EMAIL = os.environ.get('BANDIT_EMAIL')
-EMAIL_BACKEND = 'ixc_django_docker.bandit.HijackedEmailBackend'
 
 # Make it clear that emails have been hijacked and from which site.
+# NOTE: This only applies to emails sent with admin-specific methods:
+# https://docs.djangoproject.com/en/2.2/ref/settings/#email-subject-prefix
 EMAIL_SUBJECT_PREFIX = '[hijacked:%s] ' % SITE_DOMAIN
 
 INSTALLED_APPS += ('bandit', )


### PR DESCRIPTION
Applied Tai's fix to hijack emails sent via
`post_office.mail.send()` as well as Django's
`send_email()` whereas previously only the latter
was hijacked.

The setting change is defensive, and only applied
on sites with post-office settings already defined.

As developed and tested against the AGSA site.