### PR TITLE
Add explicit `git clone` step to Codefresh builds

### DIFF
--- a/project_template/codefresh.yml
+++ b/project_template/codefresh.yml
@@ -1,6 +1,12 @@
 version: '1.0'
 
 steps:
+  main_clone:
+    title: Cloning main repository...
+    type: git-clone
+    repo: '${{CF_REPO_OWNER}}/${{CF_REPO_NAME}}'
+    revision: '${{CF_REVISION}}'
+
   build_image:
     type: build
     title: Building Docker Image


### PR DESCRIPTION
Codefresh.io recently changed their service to
organise around the new "project" metaphor instead
of "repository". As part of this change they
decoupled repositories from build pipelines.

The upshot of all this is that newly-created
Codefresh.io pipelines (or projects, I guess)
must include an explicit step to clone the
contents of a git repository, whereas previously
this step was implicit.

This updated codefresh.yml template file includes
the new `git clone` step, copied exactly as
defined and recommended by the service.

See https://codefresh.io/docs/docs/codefresh-yaml/steps/git-clone/