### PR TITLE
Update transcrypt for merge and pre-commit features

### DIFF
--- a/ixc_django_docker/bin/transcrypt
+++ b/ixc_django_docker/bin/transcrypt
@@ -321,11 +321,31 @@ save_helper_scripts() {
 	cat <<-'EOF' >"${GIT_DIR}/crypt/merge"
 		#!/usr/bin/env bash
 		# Decrypt BASE, LOCAL, and REMOTE versions of file being merged
-		echo "$(./.git/crypt/textconv $1)" > $1
-		echo "$(./.git/crypt/textconv $2)" > $2
-		echo "$(./.git/crypt/textconv $3)" > $3
-		# Use git's internal merge-file to merge the decrypted files
-		git merge-file --marker-size=$4 -L local -L base -L remote $2 $1 $3
+		echo "$(cat $1 | ./.git/crypt/smudge)" > $1
+		echo "$(cat $2 | ./.git/crypt/smudge)" > $2
+		echo "$(cat $3 | ./.git/crypt/smudge)" > $3
+
+		# Merge the decrypted files to the working copy named by $5
+		# We must redirect stdout to $5 here instead of letting merge-file write to
+		# $2 as it would by default, because we need $5 to contain the final result
+		# content so a later crypt `clean` generates the correct hash salt value
+		git merge-file --stdout --marker-size=$4 -L local -L base -L remote $2 $1 $3 > $5
+
+		if [[ "$?" == "0" ]]; then
+		  # If the merge was successful (no conflicts) re-encrypt the merged working
+		  # copy file to the incoming "local" temp file $2 which git will then
+		  # update in the index during the "Auto-merging" step.
+		  # Git needs the cleaned copy to avoid triggering the error:
+		  #     error: add_cacheinfo failed to refresh for path 'FILE'; merge aborting.
+		  echo "$(cat $5 | ./.git/crypt/clean $5)" > $2
+		  exit 0
+		else
+		  # If the merge was not successful, copy the merged working copy file to the
+		  # "local" temp file $2 which git will then re-copy back to the working copy
+		  # so the user can fix it manually
+		  cp $5 $2
+		  exit 1
+		fi
 	EOF
 
 	# make scripts executable

--- a/ixc_django_docker/bin/transcrypt
+++ b/ixc_django_docker/bin/transcrypt
@@ -7,7 +7,7 @@
 # a Git repository. It utilizes OpenSSL's symmetric cipher routines and follows
 # the gitattributes(5) man page regarding the use of filters.
 #
-# Copyright (c) 2014-2017 Aaron Bull Schaefer <aaron@elasticdog.com>
+# Copyright (c) 2014-2018 Aaron Bull Schaefer <aaron@elasticdog.com>
 # This source code is provided under the terms of the MIT License
 # that can be be found in the LICENSE file.
 #
@@ -15,7 +15,7 @@
 ##### CONSTANTS
 
 # the release version of this script
-readonly VERSION='1.0.3'
+readonly VERSION='1.1.0'
 
 # the default cipher to utilize
 readonly DEFAULT_CIPHER='aes-256-cbc'
@@ -136,14 +136,16 @@ run_safety_checks() {
 
 # unset the cipher variable if it is not supported by openssl
 validate_cipher() {
-	# Support for OpenSSL versions after and before 1.1.0
-	local list_cipher_commands="openssl list-cipher-commands"
-	if [[ $($list_cipher_commands 2> /dev/null) ]]; then
-		local supported=$(openssl list-cipher-commands | grep --line-regexp "$cipher")
+	local list_cipher_commands
+	if openssl list-cipher-commands &> /dev/null; then
+		# OpenSSL < v1.1.0
+		list_cipher_commands='openssl list-cipher-commands'
 	else
-		list_cipher_commands="openssl list -cipher-commands"
-		local supported=$(openssl list -cipher-commands | tr -s ' ' '\n' | grep --line-regexp "$cipher")
+		# OpenSSL >= v1.1.0
+		list_cipher_commands='openssl list -cipher-commands'
 	fi
+
+	local supported=$($list_cipher_commands | tr -s ' ' '\n' | grep --line-regexp "$cipher")
 	if [[ ! $supported ]]; then
 		if [[ $interactive ]]; then
 			printf '"%s" is not a valid cipher; choose one of the following:\n\n' "$cipher"
@@ -316,15 +318,69 @@ save_helper_scripts() {
 		fi
 	EOF
 
+	cat <<-'EOF' >"${GIT_DIR}/crypt/merge"
+		#!/usr/bin/env bash
+		# Decrypt BASE, LOCAL, and REMOTE versions of file being merged
+		echo "$(./.git/crypt/textconv $1)" > $1
+		echo "$(./.git/crypt/textconv $2)" > $2
+		echo "$(./.git/crypt/textconv $3)" > $3
+		# Use git's internal merge-file to merge the decrypted files
+		git merge-file --marker-size=$4 -L local -L base -L remote $2 $1 $3
+	EOF
+
 	# make scripts executable
-	for script in {clean,smudge,textconv}; do
+	for script in {clean,smudge,textconv,merge}; do
 		chmod 0755 "${GIT_DIR}/crypt/${script}"
 	done
+}
+
+# save helper hooks under the repository's git directory
+save_helper_hooks() {
+	# Install pre-commit hook script
+	pre_commit_hook="${GIT_DIR}/hooks/pre-commit"
+
+	if [[ -f "$pre_commit_hook" ]]; then
+		printf 'WARNING:\n' $pre_commit_hook >&2
+		printf 'Cannot install Git pre-commit hook script because file already exists: %s\n' $pre_commit_hook >&2
+		pre_commit_hook="pre-commit-crypt"
+		printf 'Please manually install the pre-commit script saved as: %s\n' $pre_commit_hook >&2
+		printf '\n'
+	fi
+
+	cat <<-'EOF' > "$pre_commit_hook"
+		#!/usr/bin/env bash
+		# Transcrypt pre-commit hook: fail if secret file in staging lacks the magic prefix "Salted" in B64
+		for secret_file in $(transcrypt --list); do
+		  # Get prefix of raw file in Git's index using the :FILENAME revision syntax
+		  firstbytes=$(git show :$secret_file | head -c 8)
+		  # An empty file does not need to be, and is not, encrypted
+		  if [[ $firstbytes == "" ]]; then
+		    :  # Do nothing
+		  # The first bytes of an encrypted file must be "Salted" in Base64
+		  elif [[ $firstbytes != "U2FsdGVk" ]]; then
+		    printf 'Transcrypt managed file is not encrypted in the Git index: %s\n' $secret_file >&2
+		    printf '\n' >&2
+		    printf 'You probably staged this file using a tool that does not apply' >&2
+		    printf ' .gitattribute filters as required by Transcrypt.\n' >&2
+		    printf '\n' >&2
+		    printf 'Fix this by re-staging the file with a compatible tool or with'
+		    printf ' Git on the command line:\n' >&2
+		    printf '\n' >&2
+		    printf '    git reset -- %s\n' $secret_file >&2
+		    printf '    git add %s\n' $secret_file >&2
+		    printf '\n' >&2
+		    exit 1
+		  fi
+		done
+	EOF
+
+	chmod 0755 "$pre_commit_hook"
 }
 
 # write the configuration to the repository's git config
 save_configuration() {
 	save_helper_scripts
+	save_helper_hooks
 
 	# write the encryption info
 	git config transcrypt.version "$VERSION"
@@ -338,15 +394,18 @@ save_configuration() {
 		git config filter.crypt.clean '"$(git rev-parse --git-common-dir)"/crypt/clean %f'
 		git config filter.crypt.smudge '"$(git rev-parse --git-common-dir)"/crypt/smudge'
 		git config diff.crypt.textconv '"$(git rev-parse --git-common-dir)"/crypt/textconv'
+		git config merge.crypt.driver '"$(git rev-parse --git-common-dir)"/crypt/merge %O %A %B %L %P'
 	else
 		git config filter.crypt.clean '"$(git rev-parse --git-dir)"/crypt/clean %f'
 		git config filter.crypt.smudge '"$(git rev-parse --git-dir)"/crypt/smudge'
 		git config diff.crypt.textconv '"$(git rev-parse --git-dir)"/crypt/textconv'
+		git config merge.crypt.driver '"$(git rev-parse --git-dir)"/crypt/merge %O %A %B %L %P'
 	fi
 	git config filter.crypt.required 'true'
 	git config diff.crypt.cachetextconv 'true'
 	git config diff.crypt.binary 'true'
 	git config merge.renormalize 'true'
+	git config merge.crypt.name 'Merge transcrypt secret files'
 
 	# add a git alias for listing encrypted files
 	git config alias.ls-crypt "!git ls-files | git check-attr --stdin filter | awk 'BEGIN { FS = \":\" }; /crypt$/{ print \$1 }'"
@@ -371,15 +430,16 @@ display_configuration() {
 
 # remove transcrypt-related settings from the repository's git config
 clean_gitconfig() {
-	git config --remove-section transcrypt
-	git config --remove-section filter.crypt
-	git config --remove-section diff.crypt
+	git config --remove-section transcrypt 2> /dev/null
+	git config --remove-section filter.crypt 2> /dev/null
+	git config --remove-section diff.crypt 2> /dev/null
+	git config --remove-section merge.crypt 2> /dev/null
 	git config --unset merge.renormalize
 
 	# remove the merge section if it's now empty
 	local merge_values=$(git config --get-regex --local 'merge\..*')
 	if [[ ! $merge_values ]]; then
-		git config --remove-section merge
+		git config --remove-section merge 2> /dev/null
 	fi
 }
 
@@ -451,10 +511,17 @@ uninstall_transcrypt() {
 		clean_gitconfig
 
 		# remove helper scripts
-		for script in {clean,smudge,textconv}; do
+		for script in {clean,smudge,textconv,merge}; do
 			[[ -f "${GIT_DIR}/crypt/${script}" ]] && rm "${GIT_DIR}/crypt/${script}"
 		done
 		[[ -d "${GIT_DIR}/crypt" ]] && rmdir "${GIT_DIR}/crypt"
+
+		# rename helper hooks (don't delete, in case user has custom changes)
+		pre_commit_hook="${GIT_DIR}/hooks/pre-commit"
+		pre_commit_hook_renamed="${GIT_DIR}/hooks/pre-commit-crypt"
+		[[ -f "$pre_commit_hook" ]] \
+			&& mv "$pre_commit_hook" "$pre_commit_hook_renamed" \
+			&& printf 'Disabled Git pre-commit hook by renaming script to %s\n\n' $pre_commit_hook_renamed
 
 		# touch all encrypted files to prevent stale stat info
 		local encrypted_files=$(git ls-crypt)
@@ -469,16 +536,16 @@ uninstall_transcrypt() {
 		# remove the alias section if it's now empty
 		local alias_values=$(git config --get-regex --local 'alias\..*')
 		if [[ ! $alias_values ]]; then
-			git config --remove-section alias
+			git config --remove-section alias 2> /dev/null
 		fi
 
 		# remove any defined crypt patterns in gitattributes
 		case $OSTYPE in
 			darwin*)
-				sed -i '' '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
+				sed -i '' '/filter=crypt diff=crypt merge=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
 				;;
 			linux*)
-				sed -i '/filter=crypt diff=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
+				sed -i '/filter=crypt diff=crypt merge=crypt[ \t]*$/d' "$GIT_ATTRIBUTES"
 				;;
 		esac
 
@@ -595,7 +662,8 @@ help() {
 	     encryption/decryption of files by utilizing OpenSSL's symmetric  cipher
 	     routines  and  Git's  built-in clean/smudge filters. It will also add a
 	     Git alias "ls-crypt" to list all transparently encrypted  files  within
-	     the repository.
+	     the  repository,  and a pre-commit hook  to prevent  accidental commits
+	     of files in plain text caused by incompatible tools.
 
 	     The  transcrypt  source  code  and full documentation may be downloaded
 	     from https://github.com/elasticdog/transcrypt.
@@ -667,7 +735,7 @@ help() {
 	     a file in your repository, the file  will  be  transparently  encrypted
 	     once you stage and commit it:
 
-	         $ echo 'sensitive_file  filter=crypt diff=crypt' >> .gitattributes
+	         $ echo 'sensitive_file  filter=crypt diff=crypt merge=crypt' >> .gitattributes
 	         $ git add .gitattributes sensitive_file
 	         $ git commit -m 'Add encrypted version of a sensitive file'
 
@@ -856,7 +924,7 @@ fi
 # ensure the git attributes file exists
 if [[ ! -f $GIT_ATTRIBUTES ]]; then
 	mkdir -p "${GIT_ATTRIBUTES%/*}"
-	printf '#pattern  filter=crypt diff=crypt\n' > "$GIT_ATTRIBUTES"
+	printf '#pattern  filter=crypt diff=crypt merge=crypt\n' > "$GIT_ATTRIBUTES"
 fi
 
 printf 'The repository has been successfully configured by transcrypt.\n'


### PR DESCRIPTION
Update the `transcrypt` encryption utility to be
based on upstream's version 1.1.0 but also with
new features from our IC fork:

- on init, add a merge driver to properly handle
  merge of secrets files with conflicting changes:
  https://github.com/ixc/transcrypt/pull/1
  The .gitattributes file is also adjusted to
  apply the merge driver.
- on init, add a Git pre-commit hook script to
  abort commit if raw content of a secrets file
  is not properly encrypted:
  https://github.com/ixc/transcrypt/pull/2
- cherry-picked upstream fix to silence spurious
  warnings:
  http://github.com/elasticdog/transcrypt/commit/9a8a1f

Script sourced from
https://github.com/ixc/transcrypt/commit/e9e1d96c