### PR TITLE
Add `manage.py` to project template.

### DIFF
--- a/ixc_django_docker/settings/__init__.py
+++ b/ixc_django_docker/settings/__init__.py
@@ -1,3 +1,4 @@
+import environs
 import os
 
 from django.core.exceptions import ImproperlyConfigured
@@ -13,7 +14,13 @@ def _(module, from_dir):
 
 
 # Get project directory from environment. This MUST already be defined.
-PROJECT_DIR = os.environ['PROJECT_DIR']
+PROJECT_DIR = env('PROJECT_DIR')
+
+# Load `.env` file into `os.environ`.
+env = environs.Env()
+env.read_env(
+    os.path.join(PROJECT_DIR, '.env'), override=env('ENVIRONS_OVERRIDE', False)
+)
 
 # Base settings.
 BASE_SETTINGS = os.environ.get(

--- a/project_template/manage.py
+++ b/project_template/manage.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+import os
+import sys
+
+# Define required `ixc-django-docker` env var.
+os.environ['PROJECT_DIR'] = os.path.abspath(os.path.dirname(__file__))
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault('ixc_django_docker.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This allows an IDD project to be run directly via `./manage.py`, without using `go.sh` to configure the environment, and therefore works in VS Code launch configs.

The `manage.py` file defines the one required `ixc-django-docker` env var (`PROJECT_DIR`), and we use `environs` to load the `.env` file into `os.environ` in settings.

If you want the `.env` file to override any existing environment variables, first export `ENVIRONS_OVERRIDE='true'`.

This is an alternative solution to https://github.com/ixc/ic-base/pull/187
